### PR TITLE
Remove redundant build flags

### DIFF
--- a/org.gnome.Documents.json
+++ b/org.gnome.Documents.json
@@ -22,8 +22,6 @@
         "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
     ],
     "build-options" : {
-        "cflags": "-O2 -g",
-        "cxxflags": "-O2 -g",
         "env": {
             "V": "1"
         }


### PR DESCRIPTION
The 3.30 runtime sets these as defaults.