### PR TITLE
Update GNOME runtime to 3.36

### DIFF
--- a/org.gnome.Documents.json
+++ b/org.gnome.Documents.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Documents",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.34",
+    "runtime-version": "3.36",
     "sdk": "org.gnome.Sdk",
     "command": "gnome-documents",
     "finish-args": [


### PR DESCRIPTION
This could save a lot of disk space since almost all GTK/GNOME apps already switched to latest runtime. Also bump `shared-modules` to latest version.